### PR TITLE
Fix archive rewrite rules

### DIFF
--- a/classes/class-woothemes-features.php
+++ b/classes/class-woothemes-features.php
@@ -97,7 +97,7 @@ class Woothemes_Features {
 			'query_var' => true,
 			'rewrite' => array( 'slug' => 'feature' ),
 			'capability_type' => 'post',
-			'has_archive' => array( 'slug' => 'features' ),
+			'has_archive' => 'features',
 			'hierarchical' => false,
 			'supports' => array( 'title', 'editor', 'thumbnail', 'page-attributes' ), 
 			'menu_position' => 5, 


### PR DESCRIPTION
The `has_archive` argument of the [register_post_type](http://codex.wordpress.org/Function_Reference/register_post_type) function only accepts a bool or string value. An array is being passed in this situation, which is causing incorrect rewrite rules to be generated.
