### PR TITLE
Changed the form values inside get_order_options to be all caps

### DIFF
--- a/classes/class-woothemes-widget-features.php
+++ b/classes/class-woothemes-widget-features.php
@@ -220,8 +220,8 @@ class Woothemes_Widget_Features extends WP_Widget {
 	 */
 	protected function get_order_options () {
 		return array(
-					'asc' => __( 'Ascending', 'woothemes-features' ), 
-					'desc' => __( 'Descending', 'woothemes-features' )
+					'ASC' => __( 'Ascending', 'woothemes-features' ), 
+					'DESC' => __( 'Descending', 'woothemes-features' )
 					);
 	} // End get_order_options()
 } // End Class


### PR DESCRIPTION
Changed the form values inside get_order_options to be all caps:

ASC
DESC

This is what the WordPress post query expects. It ignores the small caps.
