### PR TITLE
Adding a Filter to the Feature Content. Related #16

### DIFF
--- a/woothemes-features-template.php
+++ b/woothemes-features-template.php
@@ -105,10 +105,12 @@ function woothemes_features ( $args = '' ) {
 				$template = str_replace( '%%TITLE%%', $title, $template );
 
 				if ( '' != $post->post_excerpt ) {
-					$template = str_replace( '%%CONTENT%%', get_the_excerpt(), $template );
+					$content = get_the_excerpt();
 				} else {
-					$template = str_replace( '%%CONTENT%%', get_the_content(), $template );
+					$content = get_the_content();
 				}
+				$content = apply_filters( 'woothemes_features_content', $content, $post );
+				$template = str_replace( '%%CONTENT%%', $content, $template );
 
 				$template = apply_filters( 'woothemes_features_template', $template, $post );
 


### PR DESCRIPTION
I'm adding a filter to the feature content. A user can use this plugin to modify the feature content before it is sent to the screen.

In my specific use can I want the ability to process shortcodes in the feature content - see [issue #16](https://github.com/woothemes/features/issues/16)

To take advantage of the filter this is all you would have to do:

``` php
function my_features_content_filter( $content ) {
    // do stuff to the content here
    return $content;
}
add_filter( 'woothemes_features_content', 'my_features_content_filter', 20 );
```
