### PR TITLE
Action hook typo

### DIFF
--- a/classes/class-woothemes-features.php
+++ b/classes/class-woothemes-features.php
@@ -60,7 +60,7 @@ class Woothemes_Features {
 		}
 
 		add_action( 'after_setup_theme', array( $this, 'ensure_post_thumbnails_support' ) );
-		add_action( 'after_theme_setup', array( $this, 'register_image_sizes' ) );
+		add_action( 'after_setup_theme', array( $this, 'register_image_sizes' ) );
 	} // End __construct()
 
 	/**


### PR DESCRIPTION
`register_image_sizes` needs to be called on `after_setup_theme` not `after_theme_setup`.

I thought I was losing my mind when the image size wasn't registering